### PR TITLE
Fix generic download filename

### DIFF
--- a/client/home/routes.py
+++ b/client/home/routes.py
@@ -15,6 +15,11 @@ def index():
         version = request.form.get('version')
         filter_by = request.form.get('filter_by')
 
-        response = controllers.get_jira_data(project=project, version=version, filter_by=filter_by)
-        return send_from_directory(directory=response.get("directory"), filename=response.get("filename"))
-    return render_template('index.html', form=form)
+        response = controllers.get_jira_data(project=project,
+                                             version=version,
+                                             filter_by=filter_by)
+        return send_from_directory(directory=response.get("directory"),
+                                   filename=response.get("filename"),
+                                   as_attachment=True)
+    return render_template(template_name_or_list='index.html',
+                           form=form)


### PR DESCRIPTION
Fixed download of file to use filename instead of downloads. This was set by adding as_attachment parameter